### PR TITLE
Fix genjava build problem by adding message_generation

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>message_generation</build_depend>
   <build_depend>actionlib</build_depend>
   <build_depend>actionlib_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>


### PR DESCRIPTION
When genjava is installed a build problem occurs that is caused by a missing build dependency. Adding the missing build_depend to message_generation fixes this.