### PR TITLE
Fix catkin files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(tf_lookup)
 
-find_package(catkin REQUIRED COMPONENTS roscpp genmsg actionlib_msgs tf)
+find_package(catkin REQUIRED COMPONENTS actionlib actionlib_msgs geometry_msgs message_generation roscpp tf)
 
 catkin_python_setup()
 
@@ -13,7 +13,7 @@ generate_messages(DEPENDENCIES actionlib_msgs geometry_msgs)
 
 catkin_package(
     INCLUDE_DIRS include
-    CATKIN_DEPENDS tf
+    CATKIN_DEPENDS actionlib_msgs geometry_msgs message_runtime tf
     )
 
 include_directories(include ${catkin_INCLUDE_DIRS})

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
   <build_depend>actionlib</build_depend>
   <build_depend>actionlib_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>message_generation</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>tf</build_depend>
 
@@ -23,6 +24,7 @@
   <run_depend>actionlib</run_depend>
   <run_depend>actionlib_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
+  <run_depend>message_runtime</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>tf</run_depend>
 


### PR DESCRIPTION
This patch fixes several errors reported by catkin_lint. This also
solves compilation problems when rosjava is installed.